### PR TITLE
Add an endpoint to view raw crash archives

### DIFF
--- a/app/crashreport/types.go
+++ b/app/crashreport/types.go
@@ -40,67 +40,67 @@ func (this *MapStringStringAllowsEmptyArray) UnmarshalJSON(data []byte) error {
 
 // CrashReport ...
 type CrashReport struct {
-	Duplicate    bool
+	Duplicate bool `json:"duplicate"`
 
-	Data       *ReportData
-	ReportDate time.Time
+	Data       *ReportData `json:"data"`
+	ReportDate time.Time   `json:"report_date"`
 
-	Version    *VersionString
+	Version *VersionString `json:"version"`
 
-	Error ReportError
+	Error ReportError `json:"error"`
 }
 
 // ReportData ...
 type ReportData struct {
-	Time              float64
-	Uptime            float64
-	FormatVersion     int64 `json:"format_version"`
-	Plugin            string
-	PluginInvolvement string `json:"plugin_involvement"`
-	General struct {
-		Name              string
-		BaseVersion       string `json:"base_version"`
-		Build             int
-		IsDev             bool `json:"is_dev"`
-		Protocol          int
-		GIT               string
-		Uname             string
-		PHP               string
-		Zend              string
-		PHPOS             string `json:"php_os"`
-		OS                string
+	Time              float64 `json:"time"`
+	Uptime            float64 `json:"uptime"`
+	FormatVersion     int64   `json:"format_version"`
+	Plugin            string  `json:"plugin"`
+	PluginInvolvement string  `json:"plugin_involvement"`
+	General           struct {
+		Name              string            `json:"name"`
+		BaseVersion       string            `json:"base_version"`
+		Build             int               `json:"build"`
+		IsDev             bool              `json:"is_dev"`
+		Protocol          int               `json:"protocol"`
+		GIT               string            `json:"git"`
+		Uname             string            `json:"uname"`
+		PHP               string            `json:"php"`
+		Zend              string            `json:"zend"`
+		PHPOS             string            `json:"php_os"`
+		OS                string            `json:"os"`
 		ComposerLibraries map[string]string `json:"composer_libraries"`
 	}
-	Error            ReportError
-	Code             MapStringStringAllowsEmptyArray
-	Plugins          interface{} `json:"plugins,omitempty"`
-	PocketmineYML    string      `json:"pocketmine.yml"`
-	ServerProperties string      `json:"server.properties"`
-	Trace            []string
+	Error            ReportError                     `json:"error"`
+	Code             MapStringStringAllowsEmptyArray `json:"code"`
+	Plugins          interface{}                     `json:"plugins,omitempty"`
+	PocketmineYML    string                          `json:"pocketmine.yml"`
+	ServerProperties string                          `json:"server.properties"`
+	Trace            []string                        `json:"trace"`
 }
 
 type ReportError struct {
-	Type    string
-	Message string
-	Line    int
-	File    string
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Line    int    `json:"line"`
+	File    string `json:"file"`
 }
 
 // Report ...
 type Report struct {
-	ID                int `db:"id"`
-	Plugin            string
-	PluginInvolvement string `db:"pluginInvolvement"`
-	Version           string
-	Build             int
-	File              string
-	Message           string
-	Line              int
-	Type              string
-	OS                string
-	SubmitDate        int64  `db:"submitDate"`
-	ReportDate        int64  `db:"reportDate"`
-	Duplicate         bool
+	ID                int    `json:"id" db:"id"`
+	Plugin            string `json:"plugin"`
+	PluginInvolvement string `json:"plugin_involvement" db:"pluginInvolvement"`
+	Version           string `json:"version"`
+	Build             int    `json:"build"`
+	File              string `json:"file"`
+	Message           string `json:"message"`
+	Line              int    `json:"line"`
+	Type              string `json:"type"`
+	OS                string `json:"os"`
+	SubmitDate        int64  `json:"submit_date" db:"submitDate"`
+	ReportDate        int64  `json:"report_date" db:"reportDate"`
+	Duplicate         bool   `json:"duplicate"`
 	ReporterName      string `db:"reporterName"`
 	ReporterEmail     string `db:"reporterEmail"`
 }

--- a/app/crashreport/types.go
+++ b/app/crashreport/types.go
@@ -40,12 +40,12 @@ func (this *MapStringStringAllowsEmptyArray) UnmarshalJSON(data []byte) error {
 
 // CrashReport ...
 type CrashReport struct {
-	Duplicate bool
+	Duplicate    bool
 
 	Data       *ReportData
 	ReportDate time.Time
 
-	Version *VersionString
+	Version    *VersionString
 
 	Error ReportError
 }
@@ -57,7 +57,7 @@ type ReportData struct {
 	FormatVersion     int64 `json:"format_version"`
 	Plugin            string
 	PluginInvolvement string `json:"plugin_involvement"`
-	General           struct {
+	General struct {
 		Name              string
 		BaseVersion       string `json:"base_version"`
 		Build             int
@@ -98,8 +98,8 @@ type Report struct {
 	Line              int
 	Type              string
 	OS                string
-	SubmitDate        int64 `db:"submitDate"`
-	ReportDate        int64 `db:"reportDate"`
+	SubmitDate        int64  `db:"submitDate"`
+	ReportDate        int64  `db:"reportDate"`
 	Duplicate         bool
 	ReporterName      string `db:"reporterName"`
 	ReporterEmail     string `db:"reporterEmail"`

--- a/app/crashreport/types.go
+++ b/app/crashreport/types.go
@@ -40,67 +40,67 @@ func (this *MapStringStringAllowsEmptyArray) UnmarshalJSON(data []byte) error {
 
 // CrashReport ...
 type CrashReport struct {
-	Duplicate bool `json:"duplicate"`
+	Duplicate bool
 
-	Data       *ReportData `json:"data"`
-	ReportDate time.Time   `json:"report_date"`
+	Data       *ReportData
+	ReportDate time.Time
 
-	Version *VersionString `json:"version"`
+	Version *VersionString
 
-	Error ReportError `json:"error"`
+	Error ReportError
 }
 
 // ReportData ...
 type ReportData struct {
-	Time              float64 `json:"time"`
-	Uptime            float64 `json:"uptime"`
-	FormatVersion     int64   `json:"format_version"`
-	Plugin            string  `json:"plugin"`
-	PluginInvolvement string  `json:"plugin_involvement"`
+	Time              float64
+	Uptime            float64
+	FormatVersion     int64 `json:"format_version"`
+	Plugin            string
+	PluginInvolvement string `json:"plugin_involvement"`
 	General           struct {
-		Name              string            `json:"name"`
-		BaseVersion       string            `json:"base_version"`
-		Build             int               `json:"build"`
-		IsDev             bool              `json:"is_dev"`
-		Protocol          int               `json:"protocol"`
-		GIT               string            `json:"git"`
-		Uname             string            `json:"uname"`
-		PHP               string            `json:"php"`
-		Zend              string            `json:"zend"`
-		PHPOS             string            `json:"php_os"`
-		OS                string            `json:"os"`
+		Name              string
+		BaseVersion       string `json:"base_version"`
+		Build             int
+		IsDev             bool `json:"is_dev"`
+		Protocol          int
+		GIT               string
+		Uname             string
+		PHP               string
+		Zend              string
+		PHPOS             string `json:"php_os"`
+		OS                string
 		ComposerLibraries map[string]string `json:"composer_libraries"`
 	}
-	Error            ReportError                     `json:"error"`
-	Code             MapStringStringAllowsEmptyArray `json:"code"`
-	Plugins          interface{}                     `json:"plugins,omitempty"`
-	PocketmineYML    string                          `json:"pocketmine.yml"`
-	ServerProperties string                          `json:"server.properties"`
-	Trace            []string                        `json:"trace"`
+	Error            ReportError
+	Code             MapStringStringAllowsEmptyArray
+	Plugins          interface{} `json:"plugins,omitempty"`
+	PocketmineYML    string      `json:"pocketmine.yml"`
+	ServerProperties string      `json:"server.properties"`
+	Trace            []string
 }
 
 type ReportError struct {
-	Type    string `json:"type"`
-	Message string `json:"message"`
-	Line    int    `json:"line"`
-	File    string `json:"file"`
+	Type    string
+	Message string
+	Line    int
+	File    string
 }
 
 // Report ...
 type Report struct {
-	ID                int    `json:"id" db:"id"`
-	Plugin            string `json:"plugin"`
-	PluginInvolvement string `json:"plugin_involvement" db:"pluginInvolvement"`
-	Version           string `json:"version"`
-	Build             int    `json:"build"`
-	File              string `json:"file"`
-	Message           string `json:"message"`
-	Line              int    `json:"line"`
-	Type              string `json:"type"`
-	OS                string `json:"os"`
-	SubmitDate        int64  `json:"submit_date" db:"submitDate"`
-	ReportDate        int64  `json:"report_date" db:"reportDate"`
-	Duplicate         bool   `json:"duplicate"`
+	ID                int `db:"id"`
+	Plugin            string
+	PluginInvolvement string `db:"pluginInvolvement"`
+	Version           string
+	Build             int
+	File              string
+	Message           string
+	Line              int
+	Type              string
+	OS                string
+	SubmitDate        int64 `db:"submitDate"`
+	ReportDate        int64 `db:"reportDate"`
+	Duplicate         bool
 	ReporterName      string `db:"reporterName"`
 	ReporterEmail     string `db:"reporterEmail"`
 }

--- a/app/handler/view.go
+++ b/app/handler/view.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
 	"regexp"
@@ -44,6 +45,40 @@ func ViewIDGet(db *database.DB) http.HandlerFunc {
 		v["HasDeletePerm"] = user.GetUserInfo(r).HasDeletePerm()
 
 		template.ExecuteTemplateParams(w, r, "view", v)
+	}
+}
+
+func ViewIDRawGet(db *database.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reportID, err := strconv.Atoi(chi.URLParam(r, "reportID"))
+		if err != nil {
+			template.ErrorTemplate(w, r, "Please specify a report", http.StatusNotFound)
+			return
+		}
+
+		var reporterName string
+		err = db.Get(&reporterName, "SELECT reporterName FROM crash_reports WHERE id = ?", reportID)
+		if err != nil {
+			log.Printf("can't find report %d in database: %v", reportID, err)
+			template.ErrorTemplate(w, r, "Report not found", http.StatusNotFound)
+			return
+		}
+
+		report, err := db.FetchReport(int64(reportID))
+		if err != nil {
+			log.Printf("error fetching report: %v", err)
+			template.ErrorTemplate(w, r, "Report not found", http.StatusNotFound)
+			return
+		}
+
+		raw, err := json.Marshal(report)
+		if err != nil {
+			log.Printf("error marshalling report: %v", err)
+			template.ErrorTemplate(w, r, "Report not found", http.StatusNotFound)
+		}
+
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write(raw)
 	}
 }
 

--- a/app/handler/view.go
+++ b/app/handler/view.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bytes"
+	"encoding/json"
 	"log"
 	"net/http"
 	"regexp"
@@ -70,8 +72,10 @@ func ViewIDRawGet(db *database.DB) http.HandlerFunc {
 			return
 		}
 
+		var buffer bytes.Buffer
+		json.Indent(&buffer, report, "", "    ")
 		w.Header().Set("content-type", "application/json")
-		_, _ = w.Write(report)
+		_, _ = w.Write(buffer.Bytes())
 	}
 }
 

--- a/app/handler/view.go
+++ b/app/handler/view.go
@@ -57,14 +57,6 @@ func ViewIDRawGet(db *database.DB) http.HandlerFunc {
 			return
 		}
 
-		var reporterName string
-		err = db.Get(&reporterName, "SELECT reporterName FROM crash_reports WHERE id = ?", reportID)
-		if err != nil {
-			log.Printf("can't find report %d in database: %v", reportID, err)
-			template.ErrorTemplate(w, r, "Report not found", http.StatusNotFound)
-			return
-		}
-
 		report, err := db.FetchRawReport(int64(reportID))
 		if err != nil {
 			log.Printf("error fetching report: %v", err)

--- a/app/handler/view.go
+++ b/app/handler/view.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 	"regexp"
@@ -64,21 +63,15 @@ func ViewIDRawGet(db *database.DB) http.HandlerFunc {
 			return
 		}
 
-		report, err := db.FetchReport(int64(reportID))
+		report, err := db.FetchRawReport(int64(reportID))
 		if err != nil {
 			log.Printf("error fetching report: %v", err)
 			template.ErrorTemplate(w, r, "Report not found", http.StatusNotFound)
 			return
 		}
 
-		raw, err := json.Marshal(report)
-		if err != nil {
-			log.Printf("error marshalling report: %v", err)
-			template.ErrorTemplate(w, r, "Report not found", http.StatusNotFound)
-		}
-
 		w.Header().Set("content-type", "application/json")
-		_, _ = w.Write(raw)
+		_, _ = w.Write(report)
 	}
 }
 

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -10,9 +10,9 @@ import (
 	"github.com/go-chi/chi/middleware"
 
 	"github.com/pmmp/CrashArchive/app"
+	"github.com/pmmp/CrashArchive/app/database"
 	"github.com/pmmp/CrashArchive/app/handler"
 	"github.com/pmmp/CrashArchive/app/template"
-	"github.com/pmmp/CrashArchive/app/database"
 	"github.com/pmmp/CrashArchive/app/user"
 	"github.com/pmmp/CrashArchive/app/webhook"
 )
@@ -42,6 +42,7 @@ func New(db *database.DB, wh *webhook.Webhook, config *app.Config) *chi.Mux {
 		r.Get("/logout", handler.LogoutGet)
 		r.Get("/list", handler.ListGet(db))
 		r.Get("/view/{reportID}", handler.ViewIDGet(db))
+		r.Get("/view/{reportID}/raw", handler.ViewIDRawGet(db))
 		r.Get("/download/{reportID}", handler.DownloadGet(db))
 		r.Get("/delete/{reportID}", handler.DeleteGet(db))
 

--- a/templates/view.html
+++ b/templates/view.html
@@ -15,6 +15,7 @@
     <ul>
         <li><a href="/search/report?id={{.ReportID}}" class="btn-floating fab-text-option">Find duplicates</a></li>
         <li><a href="/download/{{.ReportID}}" class="btn-floating fab-text-option">Download</a></li>
+        <li><a href="/view/{{.ReportID}}/raw" class="btn-floating fab-text-option">View raw</a></li>
         {{if .HasDeletePerm}}
         <li><a onclick="deleteHandler()" class="btn-floating fab-text-option">Delete</a></li>
         {{end}}


### PR DESCRIPTION
Implements raw report endpoint as mentioned in #23.

Raw reports can be viewed by adding ``/raw`` to the end of a report view (e.g. ``/view/1/raw``) or by clicking ``Menu > View raw`` at the bottom right when viewing a report.

[Example raw report](https://pastebin.com/aq61Uk8d) (Obtained from [4800953](https://crash.pmmp.io/view/4800953))
> A prettified version of the raw data can be found [here](https://pastebin.com/s3wSP2QP)